### PR TITLE
Fix killing canplayer

### DIFF
--- a/controls.c
+++ b/controls.c
@@ -337,8 +337,8 @@ void play_can_traffic() {
 	if(execlp("canplayer", "canplayer", "-I", traffic_log, "-l", "i", can2can, NULL) == -1) printf("WARNING: Could not execute canplayer. No bg data\n");
 }
 
-void kill_child(int sig) {
-	kill(play_id, SIGKILL);
+void kill_child() {
+	kill(play_id, SIGINT);
 }
 
 void redraw_screen() {
@@ -520,14 +520,16 @@ int main(int argc, char *argv[]) {
   }
 
   if(play_traffic) {
-	signal(SIGALRM,(void (*)(int))kill_child);
 	play_id = fork();
 	if((int)play_id == -1) {
 		printf("Error: Couldn't fork bg player\n");
 		exit(-1);
-	} else if (play_id != 0) {
+	} else if (play_id == 0) {
 		play_can_traffic();
+		// Shouldn't return
+		exit(0);
 	}
+	atexit(kill_child);
   }
 
   // GUI Setup
@@ -761,7 +763,6 @@ int main(int argc, char *argv[]) {
     SDL_Delay(5);
   }
 
-  kill_child(SIGKILL);
   close(s);
   SDL_DestroyTexture(base_texture);
   SDL_FreeSurface(image);


### PR DESCRIPTION
pid wasn't tracked correctly, leading to the `kill_child` call just
calling `kill(0, SIGKILL)`.

This properly tracks the pid and uses `atexit` to more cleanly call
`kill_child`.

Without my change:
```bash
➜  ICSim git:(om) ✗ strace -e kill -f ./controls vcan0
strace: Process 8738 attached
[pid  8738] kill(0, SIGKILL[3]    8735 killed     strace -e kill -f ./controls vcan0
```

With my change:
```bash
➜  ICSim git:(om) ✗ make
gcc -I/usr/include/SDL2   -c -o controls.o controls.c
gcc -I/usr/include/SDL2 -o controls controls.c -lSDL2 -lSDL2_image
➜  ICSim git:(om) ✗ strace -e kill -f ./controls vcan0
strace: Process 8982 attached
[pid  8981] kill(8982, SIGKILL)         = 0
[pid  8981] +++ exited with 0 +++
+++ killed by SIGKILL +++
```