### PR TITLE
Fix canvas glitches

### DIFF
--- a/icsim.c
+++ b/icsim.c
@@ -425,7 +425,7 @@ int main(int argc, char *argv[]) {
   if(window == NULL) {
 	printf("Window could not be shown\n");
   }
-  renderer = SDL_CreateRenderer(window, -1, 0);
+  renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED | SDL_RENDERER_PRESENTVSYNC);
   SDL_Surface *image = IMG_Load(get_data("ic.png"));
   SDL_Surface *needle = IMG_Load(get_data("needle.png"));
   SDL_Surface *sprites = IMG_Load(get_data("spritesheet.png"));


### PR DESCRIPTION
Fixed the issues of black edges on both sides of the dashboard canvas and screen flickering and tearing.

In some operating systems, there are issues with the SDL2 vsync/renderer driver. Their SDL2 is a newer version, and the internal renderer/backend implementation of SDL2 has changed. ICSim does not enforce SDL_RENDERER_PRESENTVSYNC, so in certain SDL2 versions, vertical synchronization is not enabled → resulting in rendering tearing.